### PR TITLE
Fix: docker container cleanup

### DIFF
--- a/py_txi/inference_server.py
+++ b/py_txi/inference_server.py
@@ -180,11 +180,12 @@ class InferenceServer(ABC):
 
     def close(self) -> None:
         if hasattr(self, "container"):
-            LOGGER.info("\t+ Stoping Docker container")
-            if self.container.status == "running":
-                self.container.stop()
-                self.container.wait()
-            LOGGER.info("\t+ Docker container stopped")
+            container = DOCKER.containers.get(self.container.id)
+            if container.status == "running":
+                LOGGER.info("\t+ Stoping Docker container")
+                container.stop()
+                container.wait()
+                LOGGER.info("\t+ Docker container stopped")
             del self.container
 
         if hasattr(self, "semaphore"):


### PR DESCRIPTION
According to https://github.com/IlyasMoutawwakil/py-txi/blob/main/py_txi/inference_server.py#L125, `self.container.status` will always be `created` if `containers.run` succeed, that's to say the related container will never get deleted.